### PR TITLE
FEATURE: Allow to remove properties, childNodes and superTypes during refinement step

### DIFF
--- a/Classes/Domain/Specification/NodeTypeNameSpecificationCollection.php
+++ b/Classes/Domain/Specification/NodeTypeNameSpecificationCollection.php
@@ -28,6 +28,17 @@ class NodeTypeNameSpecificationCollection implements \IteratorAggregate
         return new self(...[...$this->nameSpecifications, $nameSpecification]);
     }
 
+    public function withoutNodeTypeName(NodeTypeNameSpecification $nameSpecification): self
+    {
+        $nameSpecificationsFiltered = array_filter(
+            $this->nameSpecifications,
+            function (NodeTypeNameSpecification $spec) use ($nameSpecification) {
+                return $spec !== $nameSpecification;
+            }
+        );
+        return new self(...$nameSpecificationsFiltered);
+    }
+
     /**
      * @param string[] $names
      */

--- a/Classes/Domain/Specification/NodeTypeSpecification.php
+++ b/Classes/Domain/Specification/NodeTypeSpecification.php
@@ -72,7 +72,15 @@ class NodeTypeSpecification
         );
     }
 
+    /**
+     * @deprecated use withTetheredNode
+     */
     public function withTeheredNode(TetheredNodeSpecification $tetheredNode): self
+    {
+        return $this->withTetheredNode($tetheredNode);
+    }
+
+    public function withTetheredNode(TetheredNodeSpecification $tetheredNode): self
     {
         return new self(
             $this->name,
@@ -85,7 +93,7 @@ class NodeTypeSpecification
         );
     }
 
-    public function withoutTeheredNode(TetheredNodeSpecification $tetheredNode): self
+    public function withoutTetheredNode(TetheredNodeSpecification $tetheredNode): self
     {
         return new self(
             $this->name,

--- a/Classes/Domain/Specification/NodeTypeSpecification.php
+++ b/Classes/Domain/Specification/NodeTypeSpecification.php
@@ -44,7 +44,8 @@ class NodeTypeSpecification
             $this->tetheredNodes,
             $this->abstract,
             $this->label,
-            $this->icon
+            $this->icon,
+            $this->optionsSpecification
         );
     }
 
@@ -71,7 +72,8 @@ class NodeTypeSpecification
             $this->tetheredNodes,
             $this->abstract,
             $this->label,
-            $this->icon
+            $this->icon,
+            $this->optionsSpecification
         );
     }
 
@@ -106,7 +108,8 @@ class NodeTypeSpecification
             $this->tetheredNodes->withoutTetheredNode($tetheredNode),
             $this->abstract,
             $this->label,
-            $this->icon
+            $this->icon,
+            $this->optionsSpecification
         );
     }
 

--- a/Classes/Domain/Specification/NodeTypeSpecification.php
+++ b/Classes/Domain/Specification/NodeTypeSpecification.php
@@ -33,12 +33,38 @@ class NodeTypeSpecification
         );
     }
 
+    public function withoutSuperType(NodeTypeNameSpecification $nodeTypeName): self
+    {
+        return new self(
+            $this->name,
+            $this->superTypes->withoutNodeTypeName($nodeTypeName),
+            $this->nodeProperties,
+            $this->tetheredNodes,
+            $this->abstract,
+            $this->label,
+            $this->icon
+        );
+    }
+
     public function withProperty(PropertySpecification $property): self
     {
         return new self(
             $this->name,
             $this->superTypes,
             $this->nodeProperties->withProperty($property),
+            $this->tetheredNodes,
+            $this->abstract,
+            $this->label,
+            $this->icon
+        );
+    }
+
+    public function withoutProperty(PropertySpecification $property): self
+    {
+        return new self(
+            $this->name,
+            $this->superTypes,
+            $this->nodeProperties->withoutProperty($property),
             $this->tetheredNodes,
             $this->abstract,
             $this->label,
@@ -53,6 +79,19 @@ class NodeTypeSpecification
             $this->superTypes,
             $this->nodeProperties,
             $this->tetheredNodes->withTetheredNode($tetheredNode),
+            $this->abstract,
+            $this->label,
+            $this->icon
+        );
+    }
+
+    public function withoutTeheredNode(TetheredNodeSpecification $tetheredNode): self
+    {
+        return new self(
+            $this->name,
+            $this->superTypes,
+            $this->nodeProperties,
+            $this->tetheredNodes->withoutTetheredNode($tetheredNode),
             $this->abstract,
             $this->label,
             $this->icon

--- a/Classes/Domain/Specification/PropertyNameSpecification.php
+++ b/Classes/Domain/Specification/PropertyNameSpecification.php
@@ -13,4 +13,8 @@ class PropertyNameSpecification
         public readonly string $name
     ) {
     }
+    public function __toString(): string
+    {
+        return $this->name;
+    }
 }

--- a/Classes/Domain/Specification/PropertySpecificationCollection.php
+++ b/Classes/Domain/Specification/PropertySpecificationCollection.php
@@ -27,6 +27,17 @@ class PropertySpecificationCollection implements \IteratorAggregate
         return new self(...[...$this->nodeProperties, $property]);
     }
 
+    public function withoutProperty(PropertySpecification $property): self
+    {
+        $propertiesFiltered = array_filter(
+            $this->nodeProperties,
+            function (PropertySpecification $spec) use ($property) {
+                return $property !== $spec;
+            }
+        );
+        return new self(... $propertiesFiltered);
+    }
+
     public function isEmpty(): bool
     {
         return empty($this->nodeProperties);

--- a/Classes/Domain/Specification/TetheredNodeNameSpecification.php
+++ b/Classes/Domain/Specification/TetheredNodeNameSpecification.php
@@ -13,4 +13,8 @@ class TetheredNodeNameSpecification
         public readonly string $name
     ) {
     }
+    public function __toString(): string
+    {
+        return $this->name;
+    }
 }

--- a/Classes/Domain/Specification/TetheredNodeSpecificationCollection.php
+++ b/Classes/Domain/Specification/TetheredNodeSpecificationCollection.php
@@ -27,6 +27,17 @@ class TetheredNodeSpecificationCollection implements \IteratorAggregate
         return new self(...[...$this->tetheredNodes, $tetheredNode]);
     }
 
+    public function withoutTetheredNode(TetheredNodeSpecification $tetheredNode): self
+    {
+        $tetheredNodesFiltered = array_filter(
+            $this->tetheredNodes,
+            function (TetheredNodeSpecification $spec) use ($tetheredNode) {
+                return $spec !== $tetheredNode;
+            }
+        );
+        return new self(...$tetheredNodesFiltered);
+    }
+
 
     public function isEmpty(): bool
     {

--- a/Classes/Domain/Wizard/SpecificationRefinementWizard.php
+++ b/Classes/Domain/Wizard/SpecificationRefinementWizard.php
@@ -184,7 +184,7 @@ class SpecificationRefinementWizard
             $type
         );
 
-        return $nodeTypeSpecification->withTeheredNode($tetheredNode);
+        return $nodeTypeSpecification->withTetheredNode($tetheredNode);
     }
 
     protected function addPropertyToNodeTypeSpecification(NodeTypeSpecification $nodeTypeSpecification): NodeTypeSpecification
@@ -239,7 +239,7 @@ class SpecificationRefinementWizard
         $name = $this->output->select("ChildNode to remove: ", [...array_keys($tetheredNodesByName), 'exit']);
 
         if (is_string($name) && array_key_exists($name, $tetheredNodesByName)) {
-            $nodeTypeSpecification = $nodeTypeSpecification->withoutTeheredNode($tetheredNodesByName[$name]);
+            $nodeTypeSpecification = $nodeTypeSpecification->withoutTetheredNode($tetheredNodesByName[$name]);
             return $nodeTypeSpecification;
         }
 


### PR DESCRIPTION
This adds the options: "remove Property", "remove ChildNode",  "remove SuperType" to the refinement wizard once they make sense.
