### PR TITLE
FEATURE: Configurable generators, support of SelectBoxEditor for array, string and int properties and option support 

### DIFF
--- a/Classes/Command/KickstartCommandController.php
+++ b/Classes/Command/KickstartCommandController.php
@@ -16,6 +16,7 @@ use Sitegeist\Noderobis\Domain\Specification\IconNameSpecification;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeLabelSpecification;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecificationFactory;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecification;
+use Sitegeist\Noderobis\Domain\Specification\OptionsSpecification;
 use Sitegeist\Noderobis\Domain\Specification\PropertySpecificationFactory;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecificationCollection;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeSpecification;
@@ -50,7 +51,7 @@ class KickstartCommandController extends CommandController
      * @param string $packageKey (optional) Package, uses fallback from configuration
      * @param array $mixin (optional) Mixin-types to add as SuperTypes, can be used multiple times
      * @param array $childNode (optional) childNode-names and childNode-NodeType seperated by a colon, can be used multiple times
-     * @param array $property (optional) property-names and property-NodeType seperated by a colon, can be used multiple times
+     * @param array $property (optional) property-names, property-NodeType and allowed values (optional), seperated by a colon, can be used multiple times - examples `--property title:string` `--property format:string:portrait,landscape`
      * @param bool $abstract (optional) By default contents and documents are created non abstract
      * @param bool $yes (optional) Skip refinement-process and apply all modifications directly
      * @return void
@@ -70,7 +71,7 @@ class KickstartCommandController extends CommandController
      * @param string $packageKey (optional) Package, uses fallback from configuration
      * @param array $mixin (optional) Mixin-types to add as SuperTypes, can be used multiple times
      * @param array $childNode (optional) childNode-names and childNode-NodeType seperated by a colon, can be used multiple times
-     * @param array $property (optional) property-names and property-NodeType seperated by a colon, can be used multiple times
+     * @param array $property (optional) property-names, property-NodeType and allowed values (optional), seperated by a colon, can be used multiple times - examples `--property title:string` `--property format:string:portrait,landscape`
      * @param bool $abstract (optional) By default contents and documents are created non abstract
      * @param bool $yes (optional) Skip refinement-process and apply all modifications directly
      * @return void
@@ -90,7 +91,7 @@ class KickstartCommandController extends CommandController
      * @param string $packageKey (optional) Package, uses fallback from configuration
      * @param array $mixin (optional) Mixin-types to add as SuperTypes, can be used multiple times
      * @param array $childNode (optional) childNode-names and childNode-NodeType seperated by a colon, can be used multiple times
-     * @param array $property (optional) property-names and property-NodeType seperated by a colon, can be used multiple times
+     * @param array $property (optional) property-names, property-NodeType and allowed values (optional), seperated by a colon, can be used multiple times - examples `--property title:string` `--property format:string:portrait,landscape`
      * @param bool $yes (optional) Skip refinement-process and apply all modifications directly
      * @return void
      * @throws \Neos\Flow\Cli\Exception\StopCommandException
@@ -110,7 +111,7 @@ class KickstartCommandController extends CommandController
      * @param string $packageKey (optional) Package, uses fallback from configuration
      * @param array $mixin (optional) Mixin-types to add as SuperTypes, can be used multiple times
      * @param array $childNode (optional) childNode-names and childNode-NodeType seperated by a colon, can be used multiple times
-     * @param array $property (optional) property-names and property-NodeType seperated by a colon, can be used multiple times
+     * @param array $property (optional) property-names, property-NodeType and allowed values (optional), seperated by a colon, can be used multiple times - examples `--property title:string` `--property format:string:portrait,landscape`
      * @param bool $abstract (optional) By default contents and documents are created non abstract
      * @param bool $yes (optional) Skip refinement-process and apply all modifications directly
      * @return void

--- a/Classes/Domain/Generator/CreateFusionRendererModificationGenerator.php
+++ b/Classes/Domain/Generator/CreateFusionRendererModificationGenerator.php
@@ -135,7 +135,7 @@ class CreateFusionRendererModificationGenerator implements ModificationGenerator
         }
 
         if ($propertyRenderers) {
-            return 'Properties:' . PHP_EOL . '<dl>' . $this->indent( PHP_EOL . implode(PHP_EOL, $propertyRenderers)) . PHP_EOL . '</dl>';
+            return 'Properties:' . PHP_EOL . '<dl>' . $this->indent(PHP_EOL . implode(PHP_EOL, $propertyRenderers)) . PHP_EOL . '</dl>';
         } else {
             return '';
         }
@@ -183,7 +183,7 @@ class CreateFusionRendererModificationGenerator implements ModificationGenerator
             $childNodeRenderers[] = '<dt>' . $name . '</dt><dd>' . $renderer . '</dd>';
         }
         if (count($childNodeRenderers) > 0) {
-            return 'ChildNodes:' . PHP_EOL . '<dl>' . $this->indent( PHP_EOL . implode(PHP_EOL, $childNodeRenderers)) . PHP_EOL . '</dl>';
+            return 'ChildNodes:' . PHP_EOL . '<dl>' . $this->indent(PHP_EOL . implode(PHP_EOL, $childNodeRenderers)) . PHP_EOL . '</dl>';
         }
         return '';
     }

--- a/Classes/Domain/Generator/NodeTypeGenerator.php
+++ b/Classes/Domain/Generator/NodeTypeGenerator.php
@@ -59,27 +59,27 @@ class NodeTypeGenerator implements NodeTypeGeneratorInterface
             $allowedValues = $nodeProperty->allowedValues;
             if ($typeOrPreset instanceof PropertyTypeSpecification) {
                 $propertyConfiguration['type'] = $typeOrPreset->type;
+
+                if ($allowedValues) {
+                    if ($propertyConfiguration['type'] === 'array') {
+                        $propertyConfiguration['ui']['inspector']['editorOptions']['multiple'] = true;
+                    }
+
+                    $allowedValuesConfig = [];
+                    foreach ($allowedValues->allowedValues as $value) {
+                        if ($propertyConfiguration['type'] === 'integer' && !is_numeric($value)) {
+                            continue;
+                        }
+                        $allowedValuesConfig[$value] = ['label' => $value];
+                    }
+                    $propertyConfiguration['ui']['inspector']['editorOptions']['values'] = $allowedValuesConfig;
+                }
             } elseif ($typeOrPreset instanceof PropertyPresetNameSpecification) {
                 $propertyConfiguration['options']['preset'] = $typeOrPreset->presetName;
             }
 
-            if ($allowedValues) {
-                $propertyConfiguration['ui']['inspector']['group'] = 'default';
-                $propertyConfiguration['ui']['inspector']['editor'] = 'Neos.Neos/Inspector/Editors/SelectBoxEditor';
-                if ($propertyConfiguration['type'] === 'array') {
-                    $propertyConfiguration['ui']['inspector']['editorOptions']['multiple'] = true;
-                }
-
-                $allowedValuesConfig = [];
-                foreach ($allowedValues->allowedValues as $value) {
-                    if ($propertyConfiguration['type'] === 'integer' && !is_numeric($value)) {
-                        continue;
-                    }
-                    $allowedValuesConfig[$value] = ['label' => $value];
-                }
-                $propertyConfiguration['ui']['inspector']['editorOptions']['values'] = $allowedValuesConfig;
-            }
-
+            $propertyConfiguration['ui']['inspector']['group'] = 'default';
+            $propertyConfiguration['ui']['inspector']['editor'] = 'Neos.Neos/Inspector/Editors/SelectBoxEditor';
             $propertyConfiguration['ui']['label'] = $nodeProperty->label?->label ?? $nodeProperty->name->name;
 
             if ($nodeProperty->description) {
@@ -130,6 +130,10 @@ class NodeTypeGenerator implements NodeTypeGeneratorInterface
                 }
                 $localConfiguration['properties'][$nodeProperty->name->name]['ui']['reloadIfChanged'] = true;
             }
+        }
+
+        if ($nodeTypeSpecification->optionsSpecification?->options) {
+            $localConfiguration['options'] = $nodeTypeSpecification->optionsSpecification->options;
         }
 
         # add icon based on specification or super type

--- a/Classes/Domain/Generator/NodeTypeGenerator.php
+++ b/Classes/Domain/Generator/NodeTypeGenerator.php
@@ -11,6 +11,7 @@ namespace Sitegeist\Noderobis\Domain\Generator;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\Utility\Exception\InvalidTypeException;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecification;
 use Sitegeist\Noderobis\Domain\Specification\TetheredNodePresetNameSpecification;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeSpecification;
@@ -55,10 +56,28 @@ class NodeTypeGenerator implements NodeTypeGeneratorInterface
             /** @var PropertySpecification $nodeProperty */
             $propertyConfiguration = [];
             $typeOrPreset = $nodeProperty->typeOrPreset;
+            $allowedValues = $nodeProperty->allowedValues;
             if ($typeOrPreset instanceof PropertyTypeSpecification) {
                 $propertyConfiguration['type'] = $typeOrPreset->type;
             } elseif ($typeOrPreset instanceof PropertyPresetNameSpecification) {
                 $propertyConfiguration['options']['preset'] = $typeOrPreset->presetName;
+            }
+
+            if ($allowedValues) {
+                $propertyConfiguration['ui']['inspector']['group'] = 'default';
+                $propertyConfiguration['ui']['inspector']['editor'] = 'Neos.Neos/Inspector/Editors/SelectBoxEditor';
+                if ($propertyConfiguration['type'] === 'array') {
+                    $propertyConfiguration['ui']['inspector']['editorOptions']['multiple'] = true;
+                }
+
+                $allowedValuesConfig = [];
+                foreach ($allowedValues->allowedValues as $value) {
+                    if ($propertyConfiguration['type'] === 'integer' && !is_numeric($value)) {
+                        continue;
+                    }
+                    $allowedValuesConfig[$value] = ['label' => $value];
+                }
+                $propertyConfiguration['ui']['inspector']['editorOptions']['values'] = $allowedValuesConfig;
             }
 
             $propertyConfiguration['ui']['label'] = $nodeProperty->label?->label ?? $nodeProperty->name->name;

--- a/Classes/Domain/Specification/NodeTypeSpecification.php
+++ b/Classes/Domain/Specification/NodeTypeSpecification.php
@@ -16,7 +16,8 @@ class NodeTypeSpecification
         public readonly TetheredNodeSpecificationCollection $tetheredNodes,
         public readonly bool $abstract,
         public readonly ?NodeTypeLabelSpecification $label = null,
-        public readonly ?IconNameSpecification $icon = null
+        public readonly ?IconNameSpecification $icon = null,
+        public readonly ?OptionsSpecification $optionsSpecification = null
     ) {
     }
 
@@ -29,7 +30,8 @@ class NodeTypeSpecification
             $this->tetheredNodes,
             $this->abstract,
             $this->label,
-            $this->icon
+            $this->icon,
+            $this->optionsSpecification
         );
     }
 
@@ -42,7 +44,8 @@ class NodeTypeSpecification
             $this->tetheredNodes,
             $this->abstract,
             $this->label,
-            $this->icon
+            $this->icon,
+            $this->optionsSpecification
         );
     }
 
@@ -55,7 +58,8 @@ class NodeTypeSpecification
             $this->tetheredNodes->withTetheredNode($tetheredNode),
             $this->abstract,
             $this->label,
-            $this->icon
+            $this->icon,
+            $this->optionsSpecification
         );
     }
 
@@ -68,7 +72,8 @@ class NodeTypeSpecification
             $this->tetheredNodes,
             $abstract,
             $this->label,
-            $this->icon
+            $this->icon,
+            $this->optionsSpecification
         );
     }
 
@@ -81,7 +86,8 @@ class NodeTypeSpecification
             $this->tetheredNodes,
             $this->abstract,
             $label,
-            $this->icon
+            $this->icon,
+            $this->optionsSpecification
         );
     }
 
@@ -94,7 +100,22 @@ class NodeTypeSpecification
             $this->tetheredNodes,
             $this->abstract,
             $this->label,
-            $icon
+            $icon,
+            $this->optionsSpecification
+        );
+    }
+
+    public function withOptionsSpecification(?OptionsSpecification $optionsSpecification): self
+    {
+        return new self(
+            $this->name,
+            $this->superTypes,
+            $this->nodeProperties,
+            $this->tetheredNodes,
+            $this->abstract,
+            $this->label,
+            $this->icon,
+            $optionsSpecification
         );
     }
 

--- a/Classes/Domain/Specification/OptionsSpecification.php
+++ b/Classes/Domain/Specification/OptionsSpecification.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\Noderobis\Domain\Specification;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+class OptionsSpecification
+{
+    /**
+     * @param array<mixed>|null $options
+     */
+    public function __construct(
+        public readonly ?array $options
+    ) {
+    }
+}

--- a/Classes/Domain/Specification/PropertyAllowedValuesSpecification.php
+++ b/Classes/Domain/Specification/PropertyAllowedValuesSpecification.php
@@ -9,11 +9,13 @@ use Neos\Flow\Annotations as Flow;
 #[Flow\Proxy(false)]
 class PropertyAllowedValuesSpecification
 {
-
+    /**
+     * @var array<int|string>
+     */
     public readonly array $allowedValues;
 
     public function __construct(
-        mixed ...$allowedValues
+        int|string ...$allowedValues
     ) {
         $this->allowedValues = $allowedValues;
     }

--- a/Classes/Domain/Specification/PropertyAllowedValuesSpecification.php
+++ b/Classes/Domain/Specification/PropertyAllowedValuesSpecification.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\Noderobis\Domain\Specification;
+
+use Neos\Flow\Annotations as Flow;
+
+#[Flow\Proxy(false)]
+class PropertyAllowedValuesSpecification
+{
+
+    public readonly array $allowedValues;
+
+    public function __construct(
+        mixed ...$allowedValues
+    ) {
+        $this->allowedValues = $allowedValues;
+    }
+
+    public function __toString(): string
+    {
+        return 'allowed values:' . implode(',', $this->allowedValues);
+    }
+}

--- a/Classes/Domain/Specification/PropertyAllowedValuesSpecification.php
+++ b/Classes/Domain/Specification/PropertyAllowedValuesSpecification.php
@@ -20,6 +20,6 @@ class PropertyAllowedValuesSpecification
 
     public function __toString(): string
     {
-        return 'allowed values:' . implode(',', $this->allowedValues);
+        return implode(',', $this->allowedValues);
     }
 }

--- a/Classes/Domain/Specification/PropertySpecification.php
+++ b/Classes/Domain/Specification/PropertySpecification.php
@@ -22,10 +22,11 @@ class PropertySpecification
 
     public function __toString(): string
     {
-        $string = $this->name->name . '(' . $this->typeOrPreset . ')';
+        $string = $this->name->name . '(' . $this->typeOrPreset;
         if ($this->allowedValues) {
-            $string .= ' - ' . $this->allowedValues;
+            $string .= ':' . $this->allowedValues;
         }
+        $string .= ')';
         return $string;
     }
 }

--- a/Classes/Domain/Specification/PropertySpecification.php
+++ b/Classes/Domain/Specification/PropertySpecification.php
@@ -12,6 +12,7 @@ class PropertySpecification
     public function __construct(
         public readonly PropertyNameSpecification $name,
         public readonly PropertyTypeSpecification|PropertyPresetNameSpecification $typeOrPreset,
+        public readonly ?PropertyAllowedValuesSpecification $allowedValues = null,
         public readonly ?PropertyLabelSpecification $label = null,
         public readonly ?PropertyDescriptionSpecification $description = null,
         public readonly ?PropertyGroupNameSpecification $group = null,
@@ -21,6 +22,10 @@ class PropertySpecification
 
     public function __toString(): string
     {
-        return $this->name->name . '(' . $this->typeOrPreset . ')';
+        $string = $this->name->name . '(' . $this->typeOrPreset . ')';
+        if ($this->allowedValues) {
+            $string .= ' - ' . $this->allowedValues;
+        }
+        return $string;
     }
 }

--- a/Classes/Domain/Specification/PropertySpecificationFactory.php
+++ b/Classes/Domain/Specification/PropertySpecificationFactory.php
@@ -25,17 +25,25 @@ class PropertySpecificationFactory
     {
         $items = [];
         foreach ($input as $item) {
-            list($name, $config) = explode(':', $item, 2);
-            $items[] = $this->generatePropertySpecificationFromCliInput($name, $config);
+            list($name, $typeOrPreset, $allowedValues) = explode(':', $item, 3);
+            $items[] = $this->generatePropertySpecificationFromCliInput($name, $typeOrPreset, explode(',', $allowedValues));
         }
         return new PropertySpecificationCollection(... $items);
     }
 
-    public function generatePropertySpecificationFromCliInput(string $name, string $type): PropertySpecification
+    public function generatePropertySpecificationFromCliInput(string $name, string $type, ?array $allowedValues = null) : PropertySpecification
     {
         $typeOrPreset = null;
         if (is_array($this->typeConfiguration) && array_key_exists($type, $this->typeConfiguration)) {
             $typeOrPreset = new PropertyTypeSpecification($type);
+            if ($typeOrPreset->type === 'integer') {
+                foreach ($allowedValues as $key => $value) {
+                    if (!is_numeric($value)) {
+                        throw new \InvalidArgumentException('At least one allowed value for '. $name . ' is not a valid integer');
+                    }
+                }
+            }
+            $allowedValues = $allowedValues ? new PropertyAllowedValuesSpecification(...$allowedValues) : null;
         } elseif (str_starts_with($type, "preset.") && is_array($this->presetConfiguration)) {
             $preset = substr($type, 7);
             $presetConfiguration = Arrays::getValueByPath($this->presetConfiguration, $preset);
@@ -50,7 +58,8 @@ class PropertySpecificationFactory
 
         return new PropertySpecification(
             new PropertyNameSpecification($name),
-            $typeOrPreset
+            $typeOrPreset,
+            $allowedValues
         );
     }
 

--- a/Classes/Domain/Specification/PropertyTypeSpecification.php
+++ b/Classes/Domain/Specification/PropertyTypeSpecification.php
@@ -16,6 +16,6 @@ class PropertyTypeSpecification
 
     public function __toString(): string
     {
-        return 'type:' . $this->type;
+        return $this->type;
     }
 }

--- a/Classes/Domain/Wizard/GenerateCodeWizard.php
+++ b/Classes/Domain/Wizard/GenerateCodeWizard.php
@@ -35,7 +35,7 @@ class GenerateCodeWizard
     #[Flow\Inject]
     protected IncludeFusionFromNodeTypesModificationGenerator $includeFusionFromNodeTypesModificationGenerator;
 
-    /** @var array<string|string>|string|null */
+    /** @var array<string|string>|null */
     #[Flow\InjectConfiguration("modificationGenerators")]
     protected array|null $modificationGeneratorConfig;
 
@@ -51,18 +51,20 @@ class GenerateCodeWizard
     {
         $modificationGenerators = [];
 
-        foreach($this->modificationGeneratorConfig as $key => $generatorClassName) {
-            if (empty($generatorClassName)) {
-                continue;
+        if ($this->modificationGeneratorConfig) {
+            foreach ($this->modificationGeneratorConfig as $key => $generatorClassName) {
+                if (empty($generatorClassName)) {
+                    continue;
+                }
+                if (!class_exists($generatorClassName)) {
+                    throw new InvalidTypeException('Generator Class ' . $generatorClassName . ' does not exist');
+                }
+                $generator = $this->objectManager->get($generatorClassName);
+                if (!$generator instanceof ModificationGeneratorInterface) {
+                    throw new InvalidTypeException('Generator Class ' . $generatorClassName . ' does not implement interface ' . ModificationGeneratorInterface::class);
+                }
+                $modificationGenerators[$key] = $generator->generateModification($package, $nodeType);
             }
-            if (!class_exists($generatorClassName)) {
-                throw new InvalidTypeException('Generator Class ' . $generatorClassName . ' does not exist');
-            }
-            $generator = $this->objectManager->get($generatorClassName);
-            if (!$generator instanceof ModificationGeneratorInterface) {
-                throw new InvalidTypeException('Generator Class ' . $generatorClassName . ' does not implement interface ' . ModificationGeneratorInterface::class);
-            }
-            $modificationGenerators[$key] = $generator->generateModification($package, $nodeType);
         }
 
         $collection = new ModificationCollection(

--- a/Classes/Domain/Wizard/GenerateCodeWizard.php
+++ b/Classes/Domain/Wizard/GenerateCodeWizard.php
@@ -12,19 +12,20 @@ use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\ConsoleOutput;
 use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\FlowPackageInterface;
+use Neos\Neos\Domain\Service\DefaultPrototypeGeneratorInterface;
+use Neos\Utility\Exception\InvalidTypeException;
 use Sitegeist\Noderobis\Domain\Generator\CreateFusionRendererModificationGenerator;
 use Sitegeist\Noderobis\Domain\Generator\CreateNodeTypeYamlFileModificationGenerator;
 use Sitegeist\Noderobis\Domain\Generator\IncludeFusionFromNodeTypesModificationGenerator;
+use Sitegeist\Noderobis\Domain\Generator\ModificationGeneratorInterface;
 use Sitegeist\Noderobis\Domain\Generator\NodeTypeGenerator;
 use Sitegeist\Noderobis\Domain\Modification\ModificationCollection;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeSpecification;
 
 class GenerateCodeWizard
 {
-    #[Flow\Inject]
-    protected NodeTypeGenerator $nodeTypeGenerator;
-
     #[Flow\Inject]
     protected CreateNodeTypeYamlFileModificationGenerator $createNodeTypeYamlFileModificationGenerator;
 
@@ -34,6 +35,13 @@ class GenerateCodeWizard
     #[Flow\Inject]
     protected IncludeFusionFromNodeTypesModificationGenerator $includeFusionFromNodeTypesModificationGenerator;
 
+    /** @var array<string|string>|string|null */
+    #[Flow\InjectConfiguration("modificationGenerators")]
+    protected array|null $modificationGeneratorConfig;
+
+    #[Flow\Inject]
+    protected ObjectManagerInterface $objectManager;
+
     public function __construct(
         private readonly ConsoleOutput $output
     ) {
@@ -41,10 +49,24 @@ class GenerateCodeWizard
 
     public function generateCode(NodeType $nodeType, FlowPackageInterface $package, bool $yes = false): void
     {
+        $modificationGenerators = [];
+
+        foreach($this->modificationGeneratorConfig as $key => $generatorClassName) {
+            if (empty($generatorClassName)) {
+                continue;
+            }
+            if (!class_exists($generatorClassName)) {
+                throw new InvalidTypeException('Generator Class ' . $generatorClassName . ' does not exist');
+            }
+            $generator = $this->objectManager->get($generatorClassName);
+            if (!$generator instanceof ModificationGeneratorInterface) {
+                throw new InvalidTypeException('Generator Class ' . $generatorClassName . ' does not implement interface ' . ModificationGeneratorInterface::class);
+            }
+            $modificationGenerators[$key] = $generator->generateModification($package, $nodeType);
+        }
+
         $collection = new ModificationCollection(
-            $this->createNodeTypeYamlFileModificationGenerator->generateModification($package, $nodeType),
-            $this->createFusionRendererModificationGenerator->generateModification($package, $nodeType),
-            $this->includeFusionFromNodeTypesModificationGenerator->generateModification($package, $nodeType)
+            ...$modificationGenerators
         );
 
         if (!$yes && $collection->isConfirmationRequired()) {

--- a/Classes/Domain/Wizard/SpecificationRefinementWizard.php
+++ b/Classes/Domain/Wizard/SpecificationRefinementWizard.php
@@ -11,6 +11,7 @@ namespace Sitegeist\Noderobis\Domain\Wizard;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\ConsoleOutput;
 use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Utility\Arrays;
 use Neos\Utility\Exception\InvalidTypeException;
 use Sitegeist\Noderobis\Domain\Specification\IconNameSpecification;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeLabelSpecification;
@@ -174,7 +175,7 @@ class SpecificationRefinementWizard
 
         if (in_array($type,$this->propertyTypesWithAllowedValues)) {
             $allowedValueList = $this->output->ask("Allowed values (comma separated): ");
-            $allowedValues = explode(',', $allowedValueList);
+            $allowedValues = Arrays::trimExplode(',', $allowedValueList);
             if ($type === 'integer') {
                 $this->output->outputLine();
                 foreach ($allowedValues as $key => $value) {

--- a/Classes/Domain/Wizard/SpecificationRefinementWizard.php
+++ b/Classes/Domain/Wizard/SpecificationRefinementWizard.php
@@ -32,6 +32,9 @@ class SpecificationRefinementWizard
     #[Flow\Inject]
     protected NodeTypeNameSpecificationFactory $nodeTypeNameSpecificationFactory;
 
+    /**
+     * @var string[]
+     */
     protected $propertyTypesWithAllowedValues = ['integer', 'string', 'array'];
 
     public function __construct(
@@ -173,19 +176,21 @@ class SpecificationRefinementWizard
         $name = $this->output->ask("Property name: ");
         $type = $this->output->select("Property type: ", $this->propertySpecificationFactory->getTypeConfiguration());
 
-        if (in_array($type,$this->propertyTypesWithAllowedValues)) {
+        if (in_array($type, $this->propertyTypesWithAllowedValues)) {
+            /**
+             * @var string $allowedValueList
+             */
             $allowedValueList = $this->output->ask("Allowed values (comma separated): ");
             $allowedValues = Arrays::trimExplode(',', $allowedValueList);
             if ($type === 'integer') {
                 $this->output->outputLine();
                 foreach ($allowedValues as $key => $value) {
                     if (!is_numeric($value)) {
-
                         $this->output->outputLine(sprintf('Warning: Allowed value "%s" is not an integer value and will be ignored', $value));
                         unset($allowedValues[$key]);
                     }
                 }
-               ksort($allowedValues);
+                ksort($allowedValues);
             }
         } else {
             $allowedValues = null;

--- a/Classes/Domain/Wizard/SpecificationRefinementWizard.php
+++ b/Classes/Domain/Wizard/SpecificationRefinementWizard.php
@@ -175,8 +175,12 @@ class SpecificationRefinementWizard
     {
         $name = $this->output->ask("Property name: ");
         $type = $this->output->select("Property type: ", $this->propertySpecificationFactory->getTypeConfiguration());
+        $allowedValues = null;
 
-        if (in_array($type, $this->propertyTypesWithAllowedValues)) {
+        if (
+            in_array($type, $this->propertyTypesWithAllowedValues) &&
+            $this->output->askConfirmation("Do you want to restrict the allowed values? (Y/n)", false)
+        ) {
             /**
              * @var string $allowedValueList
              */
@@ -192,8 +196,6 @@ class SpecificationRefinementWizard
                 }
                 ksort($allowedValues);
             }
-        } else {
-            $allowedValues = null;
         }
 
         if (!is_string($name) || !is_string($type)) {

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,6 +8,12 @@ Sitegeist:
       Document: Neos.Neos:Document
       Content: Neos.Neos:Content
 
+    # modification generators that will be applied
+    modificationGenerators:
+      createNodeTypeYamlFile: '\Sitegeist\Noderobis\Domain\Generator\CreateNodeTypeYamlFileModificationGenerator'
+      createFusionRenderer: '\Sitegeist\Noderobis\Domain\Generator\CreateFusionRendererModificationGenerator'
+      includeFusionFromNodeTypes: '\Sitegeist\Noderobis\Domain\Generator\IncludeFusionFromNodeTypesModificationGenerator'
+
     # configuration for accessing and rendering properties in fusion the key `default` is used if no special
     # config is found for a type
     properties:

--- a/Tests/Unit/Domain/Generator/NodeTypeGeneratorTest.php
+++ b/Tests/Unit/Domain/Generator/NodeTypeGeneratorTest.php
@@ -12,6 +12,7 @@ use Sitegeist\Noderobis\Domain\Generator\NodeTypeGenerator;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecification;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecificationCollection;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeSpecification;
+use Sitegeist\Noderobis\Domain\Specification\OptionsSpecification;
 use Sitegeist\Noderobis\Domain\Specification\PropertySpecificationCollection;
 use Sitegeist\Noderobis\Domain\Specification\TetheredNodeSpecificationCollection;
 
@@ -88,7 +89,23 @@ class NodeTypeGeneratorTest extends TestCase
     /**
      * @test
      */
-    public function missingSuperTyypesYieldNodeTypeNotFoundException()
+    public function optionsAreAssigned()
+    {
+        $specification = $this->prepareSpecification();
+
+        $optionSpecification = new OptionsSpecification(['foo' => 'bar', 'test' => ['test1', 'test2']]);
+        $specification = $specification->withOptionsSpecification($optionSpecification);
+
+        $nodeType = $this->generator->generateNodeType($specification);
+
+        $this->assertInstanceOf(NodeType::class, $nodeType);
+        $this->assertSame($optionSpecification->options, $nodeType->getOptions());
+    }
+
+    /**
+     * @test
+     */
+    public function missingSuperTypesYieldNodeTypeNotFoundException()
     {
         $specification = $this->prepareSpecification(
             name: NodeTypeNameSpecification::fromString("Vendor.Package:Example"),
@@ -117,6 +134,7 @@ class NodeTypeGeneratorTest extends TestCase
             $nodeProperties ?? new PropertySpecificationCollection(),
             $tetheredNodes ?? new TetheredNodeSpecificationCollection(),
             $abstract ?? false,
+            null,
             null,
             null
         );


### PR DESCRIPTION
1. The setting `Sitegeist.Noderobis.modificationGenerators` allows to configure the modification generators that are used to generate the code for new nodetypes.

2. Properties of type string. int and  array can now be defined with a list of allowed values in which case the generated nodeType uses the select-box-editor.

3. The nodeTypeSpecification now support the OptionsSpecification to specify the options in the nodetype configuration as array.