### PR TITLE
BUGFIX: Assign select box editor only when needed

### DIFF
--- a/Classes/Domain/Generator/NodeTypeGenerator.php
+++ b/Classes/Domain/Generator/NodeTypeGenerator.php
@@ -72,6 +72,7 @@ class NodeTypeGenerator implements NodeTypeGeneratorInterface
                         }
                         $allowedValuesConfig[$value] = ['label' => $value];
                     }
+                    $propertyConfiguration['ui']['inspector']['editor'] = 'Neos.Neos/Inspector/Editors/SelectBoxEditor';
                     $propertyConfiguration['ui']['inspector']['editorOptions']['values'] = $allowedValuesConfig;
                 }
             } elseif ($typeOrPreset instanceof PropertyPresetNameSpecification) {
@@ -79,7 +80,6 @@ class NodeTypeGenerator implements NodeTypeGeneratorInterface
             }
 
             $propertyConfiguration['ui']['inspector']['group'] = 'default';
-            $propertyConfiguration['ui']['inspector']['editor'] = 'Neos.Neos/Inspector/Editors/SelectBoxEditor';
             $propertyConfiguration['ui']['label'] = $nodeProperty->label?->label ?? $nodeProperty->name->name;
 
             if ($nodeProperty->description) {

--- a/Classes/Domain/Specification/PropertySpecificationFactory.php
+++ b/Classes/Domain/Specification/PropertySpecificationFactory.php
@@ -12,11 +12,11 @@ class PropertySpecificationFactory
 {
     /** @var array<string, mixed>|null */
     #[Flow\InjectConfiguration("nodeTypes.presets.properties", "Neos.Neos")]
-    protected array|null $presetConfiguration;
+    protected array|null $presetConfiguration = null;
 
     /** @var array<string, mixed>|null */
     #[Flow\InjectConfiguration("userInterface.inspector.dataTypes", "Neos.Neos")]
-    protected array|null $typeConfiguration;
+    protected array|null $typeConfiguration = null;
 
     /**
      * @param array<int, string> $input
@@ -111,11 +111,9 @@ class PropertySpecificationFactory
         }
 
         if (is_array($this->presetConfiguration)) {
-            if (is_array($this->presetConfiguration)) {
-                $presetPathes = ConfigurationUtility::findConfigurationPathesByKey($this->presetConfiguration, 'type');
-                foreach ($presetPathes as $presetPathe) {
-                    $options[] = 'preset.' . $presetPathe;
-                }
+            $presetPathes = ConfigurationUtility::findConfigurationPathesByKey($this->presetConfiguration, 'type');
+            foreach ($presetPathes as $presetPathe) {
+                $options[] = 'preset.' . $presetPathe;
             }
         }
 

--- a/Tests/Unit/BaseTestCase.php
+++ b/Tests/Unit/BaseTestCase.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\Noderobis\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+class BaseTestCase extends TestCase
+{
+    /**
+     * Injects $dependency into property $name of $target
+     *
+     * This is a convenience method for setting a protected or private property in
+     * a test subject for the purpose of injecting a dependency.
+     *
+     * @param object $target The instance which needs the dependency
+     * @param string $name Name of the property to be injected
+     * @param mixed $dependency The dependency to inject – usually an object but can also be any other type
+     * @return void
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     */
+    protected function inject($target, $name, $dependency)
+    {
+        if (!is_object($target)) {
+            throw new \InvalidArgumentException('Wrong type for argument $target, must be object.');
+        }
+
+        $objectReflection = new \ReflectionObject($target);
+        $methodNamePart = strtoupper($name[0]) . substr($name, 1);
+        if ($objectReflection->hasMethod('set' . $methodNamePart)) {
+            $methodName = 'set' . $methodNamePart;
+            $target->$methodName($dependency);
+        } elseif ($objectReflection->hasMethod('inject' . $methodNamePart)) {
+            $methodName = 'inject' . $methodNamePart;
+            $target->$methodName($dependency);
+        } elseif ($objectReflection->hasProperty($name)) {
+            $property = $objectReflection->getProperty($name);
+            $property->setAccessible(true);
+            $property->setValue($target, $dependency);
+        } else {
+            throw new \RuntimeException('Could not inject ' . $name . ' into object of type ' . get_class($target));
+        }
+    }
+}

--- a/Tests/Unit/Domain/Modification/AddToFileModificationTest.php
+++ b/Tests/Unit/Domain/Modification/AddToFileModificationTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace Sitegeist\Noderobis\Tests\Unit\Domain\Modification;
 
 use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Sitegeist\Noderobis\Domain\Modification\AddToFileModification;
+use Sitegeist\Noderobis\Tests\Unit\BaseTestCase;
 
-class AddToFileModificationTest extends TestCase
+class AddToFileModificationTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/Tests/Unit/Domain/Modification/ModificationCollectionTest.php
+++ b/Tests/Unit/Domain/Modification/ModificationCollectionTest.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace Sitegeist\Noderobis\Tests\Unit\Domain\Modification;
 
-use PHPUnit\Framework\TestCase;
 use Sitegeist\Noderobis\Domain\Modification\ModificationCollection;
 use Sitegeist\Noderobis\Domain\Modification\ModificationInterface;
+use Sitegeist\Noderobis\Tests\Unit\BaseTestCase;
 
-class ModificationCollectionTest extends TestCase
+class ModificationCollectionTest extends BaseTestCase
 {
     /**
      * @test

--- a/Tests/Unit/Domain/Modification/WriteFileModificationTest.php
+++ b/Tests/Unit/Domain/Modification/WriteFileModificationTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace Sitegeist\Noderobis\Tests\Unit\Domain\Modification;
 
 use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\TestCase;
 use Sitegeist\Noderobis\Domain\Modification\WriteFileModification;
+use Sitegeist\Noderobis\Tests\Unit\BaseTestCase;
 
-class WriteFileModificationTest extends TestCase
+class WriteFileModificationTest extends BaseTestCase
 {
     protected function setUp(): void
     {

--- a/Tests/Unit/Utility/ConfigurationUtilityTest.php
+++ b/Tests/Unit/Utility/ConfigurationUtilityTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Sitegeist\Noderobis\Tests\Utility;
 
-use PHPUnit\Framework\TestCase;
+use Sitegeist\Noderobis\Tests\Unit\BaseTestCase;
 use Sitegeist\Noderobis\Utility\ConfigurationUtility;
 
-class ConfigurationUtilityTest extends TestCase
+class ConfigurationUtilityTest extends BaseTestCase
 {
 
     public function provideDataForFindConfigurationPathesByKeyWorks(): array


### PR DESCRIPTION
This change ensures that the select box editor is only used when a list of predefined values was specified.