### PR TITLE
FEATURE: Add `./flow kickstart:refine` command to continue working on previously kickstarted nodeTypes

### DIFF
--- a/Classes/Command/KickstartCommandController.php
+++ b/Classes/Command/KickstartCommandController.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Sitegeist\Noderobis\Command;
 
+use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Sitegeist\Noderobis\Domain\Generator\NodeTypeGenerator;
@@ -17,9 +18,11 @@ use Sitegeist\Noderobis\Domain\Specification\NodeTypeLabelSpecification;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecificationFactory;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecification;
 use Sitegeist\Noderobis\Domain\Specification\OptionsSpecification;
+use Sitegeist\Noderobis\Domain\Specification\PropertySpecification;
 use Sitegeist\Noderobis\Domain\Specification\PropertySpecificationFactory;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecificationCollection;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeSpecification;
+use Sitegeist\Noderobis\Domain\Specification\TetheredNodeSpecification;
 use Sitegeist\Noderobis\Domain\Specification\TetheredNodeSpecificationFactory;
 use Sitegeist\Noderobis\Domain\Wizard\DeterminePrimarySuperTypeWizard;
 use Sitegeist\Noderobis\Domain\Wizard\GenerateCodeWizard;
@@ -45,60 +48,64 @@ class KickstartCommandController extends CommandController
     /**
      * @phpstan-param array<int, string> $property
      * @phpstan-param array<int, string> $childNode
-     * @phpstan-param array<int, string> $mixin
+     * @phpstan-param array<int, string> $superType
      *
      * @param string $name Node Name, last part of NodeType
      * @param string $packageKey (optional) Package, uses fallback from configuration
-     * @param array $mixin (optional) Mixin-types to add as SuperTypes, can be used multiple times
+     * @param array $superType (optional) superTypes, can be used multiple times
      * @param array $childNode (optional) childNode-names and childNode-NodeType seperated by a colon, can be used multiple times
      * @param array $property (optional) property-names, property-NodeType and allowed values (optional), seperated by a colon, can be used multiple times - examples `--property title:string` `--property format:string:portrait,landscape`
+     * @param string $icon (optional) Node icon name
+     * @param string $label (optional) Node label
      * @param bool $abstract (optional) By default contents and documents are created non abstract
      * @param bool $yes (optional) Skip refinement-process and apply all modifications directly
      * @return void
      * @throws \Neos\Flow\Cli\Exception\StopCommandException
      */
-    public function documentCommand(string $name, ?string $packageKey = null, array $mixin = [], array $childNode = [], array $property = [], ?bool $abstract = null, bool $yes = false): void
+    public function documentCommand(string $name, ?string $packageKey = null, array $superType = [], array $childNode = [], array $property = [], ?string $icon = null, ?string $label = null, ?bool $abstract = null, bool $yes = false): void
     {
-        $this->nodetypeCommand(BaseType::Document, $name, $packageKey, $mixin, $childNode, $property, $abstract, $yes);
+        $this->nodetypeCommand(BaseType::Document, $name, $packageKey, $superType, $childNode, $property, $icon, $label,$abstract, $yes);
     }
 
     /**
      * @phpstan-param array<int, string> $property
      * @phpstan-param array<int, string> $childNode
-     * @phpstan-param array<int, string> $mixin
+     * @phpstan-param array<int, string> $superType
      *
      * @param string $name Node Name, last part of NodeType
      * @param string $packageKey (optional) Package, uses fallback from configuration
-     * @param array $mixin (optional) Mixin-types to add as SuperTypes, can be used multiple times
+     * @param array $superType (optional) superTypes, can be used multiple times
      * @param array $childNode (optional) childNode-names and childNode-NodeType seperated by a colon, can be used multiple times
      * @param array $property (optional) property-names, property-NodeType and allowed values (optional), seperated by a colon, can be used multiple times - examples `--property title:string` `--property format:string:portrait,landscape`
+     * @param string $icon (optional) Node icon name
+     * @param string $label (optional) Node label
      * @param bool $abstract (optional) By default contents and documents are created non abstract
      * @param bool $yes (optional) Skip refinement-process and apply all modifications directly
      * @return void
      * @throws \Neos\Flow\Cli\Exception\StopCommandException
      */
-    public function contentCommand(string $name, ?string $packageKey = null, array $mixin = [], array $childNode = [], array $property = [], ?bool $abstract = null, bool $yes = false): void
+    public function contentCommand(string $name, ?string $packageKey = null, array $superType = [], array $childNode = [], array $property = [], ?string $icon = null, ?string $label = null, ?bool $abstract = null, bool $yes = false): void
     {
-        $this->nodetypeCommand(BaseType::Content, $name, $packageKey, $mixin, $childNode, $property, $abstract, $yes);
+        $this->nodetypeCommand(BaseType::Content, $name, $packageKey, $superType, $childNode, $property, $icon, $label, $abstract, $yes);
     }
 
     /**
      * @phpstan-param array<int, string> $property
      * @phpstan-param array<int, string> $childNode
-     * @phpstan-param array<int, string> $mixin
+     * @phpstan-param array<int, string> $superType
      *
      * @param string $name Node Name, last part of NodeType
      * @param string $packageKey (optional) Package, uses fallback from configuration
-     * @param array $mixin (optional) Mixin-types to add as SuperTypes, can be used multiple times
+     * @param array $superType (optional) superTypes, can be used multiple times
      * @param array $childNode (optional) childNode-names and childNode-NodeType seperated by a colon, can be used multiple times
      * @param array $property (optional) property-names, property-NodeType and allowed values (optional), seperated by a colon, can be used multiple times - examples `--property title:string` `--property format:string:portrait,landscape`
      * @param bool $yes (optional) Skip refinement-process and apply all modifications directly
      * @return void
      * @throws \Neos\Flow\Cli\Exception\StopCommandException
      */
-    public function mixinCommand(string $name, ?string $packageKey = null, array $mixin = [], array $childNode = [], array $property = [], bool $yes = false): void
+    public function mixinCommand(string $name, ?string $packageKey = null, array $superType = [], array $childNode = [], array $property = [], bool $yes = false): void
     {
-        $this->nodetypeCommand(BaseType::Mixin, $name, $packageKey, $mixin, $childNode, $property, true, $yes);
+        $this->nodetypeCommand(BaseType::Mixin, $name, $packageKey, $superType, $childNode, $property, null, null, true, $yes);
     }
 
     /**
@@ -109,15 +116,17 @@ class KickstartCommandController extends CommandController
      * @param BaseType $baseType Base type (Content, Document or Mixin)
      * @param string $name Node Name, last part of NodeType
      * @param string $packageKey (optional) Package, uses fallback from configuration
-     * @param array $mixin (optional) Mixin-types to add as SuperTypes, can be used multiple times
+     * @param array $superType (optional) superTypes, can be used multiple times
      * @param array $childNode (optional) childNode-names and childNode-NodeType seperated by a colon, can be used multiple times
      * @param array $property (optional) property-names, property-NodeType and allowed values (optional), seperated by a colon, can be used multiple times - examples `--property title:string` `--property format:string:portrait,landscape`
+     * @param string|null $icon (optional) Icon name
+     * @param string|null $label (optional) Node label
      * @param bool $abstract (optional) By default contents and documents are created non abstract
      * @param bool $yes (optional) Skip refinement-process and apply all modifications directly
      * @return void
      * @throws \Neos\Flow\Cli\Exception\StopCommandException
      */
-    protected function nodetypeCommand(BaseType $baseType, string $name, ?string $packageKey = null, array $mixin = [], array $childNode = [], array $property = [], ?bool $abstract = null, bool $yes = false): void
+    protected function nodetypeCommand(BaseType $baseType, string $name, ?string $packageKey = null, array $superType = [], array $childNode = [], array $property = [], ?string $icon = null, ?string $label = null, ?bool $abstract = null, bool $yes = false): void
     {
         $determineFlowPackageWizard = new DetermineFlowPackageWizard();
         $package = $determineFlowPackageWizard->determineFlowPackage($packageKey);
@@ -127,10 +136,12 @@ class KickstartCommandController extends CommandController
 
         $nodeTypeSpecification = new NodeTypeSpecification(
             NodeTypeNameSpecification::fromString($package->getPackageKey() . ':' . $baseType->value . '.' . ucfirst($name)),
-            $primarySuperType ? NodeTypeNameSpecificationCollection::fromStringArray([$primarySuperType->getName(), ...$mixin]) : new NodeTypeNameSpecificationCollection(),
+            $primarySuperType ? NodeTypeNameSpecificationCollection::fromStringArray([$primarySuperType->getName(), ...$superType]) : new NodeTypeNameSpecificationCollection(),
             $this->propertySpecificationFactory->generatePropertySpecificationCollectionFromCliInputArray($property),
             $this->tetheredNodeSpecificationFactory->generateTetheredNodeSpecificationCollectionFromCliInputArray($childNode),
-            is_bool($abstract) ? $abstract : !($primarySuperType && ($primarySuperType->isOfType('Neos.Neos:Document') || $primarySuperType->isOfType('Neos.Neos:Content')))
+            is_bool($abstract) ? $abstract : !($primarySuperType && ($primarySuperType->isOfType('Neos.Neos:Document') || $primarySuperType->isOfType('Neos.Neos:Content'))),
+            $label ? new NodeTypeLabelSpecification($label): null,
+            $icon ? new IconNameSpecification($icon) : null,
         );
 
         if (!$yes) {
@@ -141,9 +152,65 @@ class KickstartCommandController extends CommandController
         $this->output->outputLine();
         $this->output->outputLine($nodeTypeSpecification->__toString());
 
+        $optionsSpecification = $nodeTypeSpecification->optionsSpecification ?? new OptionsSpecification([]);
+        $optionsSpecification = $optionsSpecification->withOption('noderobis.cliCommand', $this->createCliCommandForLaterRestarting($baseType, $primarySuperType, $nodeTypeSpecification));
+        $nodeTypeSpecification = $nodeTypeSpecification->withOptionsSpecification($optionsSpecification);
+
         $nodeType = $this->nodeTypeGenerator->generateNodeType($nodeTypeSpecification);
 
         $generateCodeWizard = new GenerateCodeWizard($this->output);
         $generateCodeWizard->generateCode($nodeType, $package, $yes);
+    }
+
+    protected function createCliCommandForLaterRestarting(BaseType $baseType, ?NodeType $primarySuperType, NodeTypeSpecification $nodeTypeSpecification): string
+    {
+        $command = './flow kickstart:' . strtolower($baseType->value);
+
+        $nameArgument = $nodeTypeSpecification->name->localName;
+        if (str_starts_with( $nameArgument, $baseType->value . '.')) {
+            $nameArgument = preg_replace('/^' . preg_quote($baseType->value . '.', '/') . '/', '', $nameArgument);
+        }
+        $command .= ' --name ' . $nameArgument;
+
+        $command .= ' --packageKey ' . $nodeTypeSpecification->name->packageKey;
+
+        /**
+         * @var NodeTypeNameSpecification $superType
+         */
+        foreach ($nodeTypeSpecification->superTypes->getIterator() as $superType) {
+            if ($primarySuperType && $primarySuperType->getName() === $superType->getFullName()) {
+                continue;
+            }
+
+            $command .= ' --superType ' . $superType;
+        }
+
+        /**
+         * @var PropertySpecification $propertySpecification
+         */
+        foreach ($nodeTypeSpecification->nodeProperties->getIterator() as $propertySpecification) {
+            $command .= ' --property ' . $propertySpecification;
+        }
+
+        /**
+         * @var TetheredNodeSpecification $tetheredNode
+         */
+        foreach ($nodeTypeSpecification->tetheredNodes->getIterator() as $tetheredNode) {
+            $command .= ' --childNode ' . $tetheredNode;
+        }
+
+        if ($nodeTypeSpecification->abstract) {
+            $command .= ' --abstract';
+        }
+
+        if ($nodeTypeSpecification->icon) {
+            $command .= ' --icon ' . $nodeTypeSpecification->icon->name;
+        }
+
+        if ($nodeTypeSpecification->label) {
+            $command .= ' --label ' . $nodeTypeSpecification->label->label;
+        }
+
+        return $command;
     }
 }

--- a/Classes/Command/KickstartCommandController.php
+++ b/Classes/Command/KickstartCommandController.php
@@ -69,7 +69,7 @@ class KickstartCommandController extends CommandController
      */
     public function documentCommand(string $name, ?string $packageKey = null, array $superType = [], array $childNode = [], array $property = [], ?string $icon = null, ?string $label = null, ?bool $abstract = null, bool $yes = false): void
     {
-        $this->nodetypeCommand(BaseType::Document, $name, $packageKey, $superType, $childNode, $property, $icon, $label,$abstract, $yes);
+        $this->nodetypeCommand(BaseType::Document, $name, $packageKey, $superType, $childNode, $property, $icon, $label, $abstract, $yes);
     }
 
     /**
@@ -116,7 +116,7 @@ class KickstartCommandController extends CommandController
     /**
      * @phpstan-param array<int, string> $property
      * @phpstan-param array<int, string> $childNode
-     * @phpstan-param array<int, string> $mixin
+     * @phpstan-param array<int, string> $superType
      *
      * @param BaseType $baseType Base type (Content, Document or Mixin)
      * @param string $name Node Name, last part of NodeType
@@ -145,7 +145,7 @@ class KickstartCommandController extends CommandController
             $this->propertySpecificationFactory->generatePropertySpecificationCollectionFromCliInputArray($property),
             $this->tetheredNodeSpecificationFactory->generateTetheredNodeSpecificationCollectionFromCliInputArray($childNode),
             is_bool($abstract) ? $abstract : !($primarySuperType && ($primarySuperType->isOfType('Neos.Neos:Document') || $primarySuperType->isOfType('Neos.Neos:Content'))),
-            $label ? new NodeTypeLabelSpecification($label): null,
+            $label ? new NodeTypeLabelSpecification($label) : null,
             $icon ? new IconNameSpecification($icon) : null,
         );
 
@@ -180,21 +180,19 @@ class KickstartCommandController extends CommandController
             $this->quit(1);
         }
 
-        $cliArguments = $nodeType->getConfiguration('options.noderobis.cli');
+        $cliCommandConfiguration = $nodeType->getConfiguration('options.noderobis.cli');
 
-        if (!$cliArguments) {
-            $this->outputLine('configuration  options.noderobis.cliArguments was not found in NodeType ' . $nodeType);
+        if (!is_array($cliCommandConfiguration)) {
+            $this->outputLine('configuration "options.noderobis.cliArguments" was not found in NodeType ' . $nodeType);
             $this->quit(1);
         }
 
-        $command = $cliArguments['command'];
-        $arguments = $cliArguments['arguments'] ?? [];
+        $cliCommand = CliCommand::fromConfiguration($cliCommandConfiguration);
 
         $this->forward(
-            $command,
+            $cliCommand->command,
             'Sitegeist\\Noderobis\\Command\\KickstartCommandController',
-            $arguments
+            $cliCommand->arguments
         );
-
     }
 }

--- a/Classes/Command/KickstartCommandController.php
+++ b/Classes/Command/KickstartCommandController.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 namespace Sitegeist\Noderobis\Command;
 
 use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
+use Neos\Flow\Cli\CommandManager;
 use Sitegeist\Noderobis\Domain\Generator\NodeTypeGenerator;
 use Sitegeist\Noderobis\Domain\Specification\BaseType;
+use Sitegeist\Noderobis\Domain\Specification\CliCommand;
 use Sitegeist\Noderobis\Domain\Specification\IconNameSpecification;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeLabelSpecification;
 use Sitegeist\Noderobis\Domain\Specification\NodeTypeNameSpecificationFactory;
@@ -26,7 +29,6 @@ use Sitegeist\Noderobis\Domain\Specification\TetheredNodeSpecification;
 use Sitegeist\Noderobis\Domain\Specification\TetheredNodeSpecificationFactory;
 use Sitegeist\Noderobis\Domain\Wizard\DeterminePrimarySuperTypeWizard;
 use Sitegeist\Noderobis\Domain\Wizard\GenerateCodeWizard;
-use Sitegeist\Noderobis\Domain\Wizard\GenerateNodeTypeWizard;
 use Sitegeist\Noderobis\Domain\Wizard\SpecificationRefinementWizard;
 use Sitegeist\Noderobis\Domain\Wizard\DetermineFlowPackageWizard;
 
@@ -44,6 +46,9 @@ class KickstartCommandController extends CommandController
 
     #[Flow\Inject]
     protected NodeTypeNameSpecificationFactory $nodeTypeNameSpecificationFactory;
+
+    #[Flow\Inject]
+    protected NodeTypeManager $nodeTypeManager;
 
     /**
      * @phpstan-param array<int, string> $property
@@ -152,8 +157,9 @@ class KickstartCommandController extends CommandController
         $this->output->outputLine();
         $this->output->outputLine($nodeTypeSpecification->__toString());
 
+        $cliCommand = CliCommand::create($baseType, $primarySuperType, $nodeTypeSpecification);
         $optionsSpecification = $nodeTypeSpecification->optionsSpecification ?? new OptionsSpecification([]);
-        $optionsSpecification = $optionsSpecification->withOption('noderobis.cliCommand', $this->createCliCommandForLaterRestarting($baseType, $primarySuperType, $nodeTypeSpecification));
+        $optionsSpecification = $optionsSpecification->withOption('noderobis.cli', $cliCommand->asArray());
         $nodeTypeSpecification = $nodeTypeSpecification->withOptionsSpecification($optionsSpecification);
 
         $nodeType = $this->nodeTypeGenerator->generateNodeType($nodeTypeSpecification);
@@ -162,55 +168,33 @@ class KickstartCommandController extends CommandController
         $generateCodeWizard->generateCode($nodeType, $package, $yes);
     }
 
-    protected function createCliCommandForLaterRestarting(BaseType $baseType, ?NodeType $primarySuperType, NodeTypeSpecification $nodeTypeSpecification): string
+    /**
+     * @param string $nodeType
+     * @return void
+     */
+    public function refineCommand(string $nodeType): void
     {
-        $command = './flow kickstart:' . strtolower($baseType->value);
-
-        $nameArgument = $nodeTypeSpecification->name->localName;
-        if (str_starts_with( $nameArgument, $baseType->value . '.')) {
-            $nameArgument = preg_replace('/^' . preg_quote($baseType->value . '.', '/') . '/', '', $nameArgument);
-        }
-        $command .= ' --name ' . $nameArgument;
-
-        $command .= ' --packageKey ' . $nodeTypeSpecification->name->packageKey;
-
-        /**
-         * @var NodeTypeNameSpecification $superType
-         */
-        foreach ($nodeTypeSpecification->superTypes->getIterator() as $superType) {
-            if ($primarySuperType && $primarySuperType->getName() === $superType->getFullName()) {
-                continue;
-            }
-
-            $command .= ' --superType ' . $superType;
+        $nodeType = $this->nodeTypeManager->getNodeType($nodeType);
+        if (!$nodeType instanceof NodeType) {
+            $this->outputLine('NodeType ' . $nodeType . ' not found');
+            $this->quit(1);
         }
 
-        /**
-         * @var PropertySpecification $propertySpecification
-         */
-        foreach ($nodeTypeSpecification->nodeProperties->getIterator() as $propertySpecification) {
-            $command .= ' --property ' . $propertySpecification;
+        $cliArguments = $nodeType->getConfiguration('options.noderobis.cli');
+
+        if (!$cliArguments) {
+            $this->outputLine('configuration  options.noderobis.cliArguments was not found in NodeType ' . $nodeType);
+            $this->quit(1);
         }
 
-        /**
-         * @var TetheredNodeSpecification $tetheredNode
-         */
-        foreach ($nodeTypeSpecification->tetheredNodes->getIterator() as $tetheredNode) {
-            $command .= ' --childNode ' . $tetheredNode;
-        }
+        $command = $cliArguments['command'];
+        $arguments = $cliArguments['arguments'] ?? [];
 
-        if ($nodeTypeSpecification->abstract) {
-            $command .= ' --abstract';
-        }
+        $this->forward(
+            $command,
+            'Sitegeist\\Noderobis\\Command\\KickstartCommandController',
+            $arguments
+        );
 
-        if ($nodeTypeSpecification->icon) {
-            $command .= ' --icon ' . $nodeTypeSpecification->icon->name;
-        }
-
-        if ($nodeTypeSpecification->label) {
-            $command .= ' --label ' . $nodeTypeSpecification->label->label;
-        }
-
-        return $command;
     }
 }

--- a/Classes/Domain/Generator/CliCommandInfoTrait.php
+++ b/Classes/Domain/Generator/CliCommandInfoTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sitegeist\Noderobis\Domain\Generator;
@@ -8,10 +9,10 @@ use Sitegeist\Noderobis\Domain\Specification\CliCommand;
 
 trait CliCommandInfoTrait
 {
-    public function createCliCommandInfoForNodeType (NodeType $nodeType): string
+    public function createCliCommandInfoForNodeType(NodeType $nodeType): string
     {
         $cliConfig = $nodeType->getConfiguration('options.noderobis.cli');
-        if ($cliConfig) {
+        if ($cliConfig && is_array($cliConfig) && array_key_exists('command', $cliConfig)) {
             $command = new CliCommand(
                 $cliConfig['command'],
                 $cliConfig['arguments'] ?? []

--- a/Classes/Domain/Generator/CliCommandInfoTrait.php
+++ b/Classes/Domain/Generator/CliCommandInfoTrait.php
@@ -5,19 +5,23 @@ declare(strict_types=1);
 namespace Sitegeist\Noderobis\Domain\Generator;
 
 use Neos\ContentRepository\Domain\Model\NodeType;
+use Sitegeist\Noderobis\Command\KickstartCommandController;
 use Sitegeist\Noderobis\Domain\Specification\CliCommand;
 
 trait CliCommandInfoTrait
 {
     public function createCliCommandInfoForNodeType(NodeType $nodeType): string
     {
-        $cliConfig = $nodeType->getConfiguration('options.noderobis.cli');
-        if ($cliConfig && is_array($cliConfig) && array_key_exists('command', $cliConfig)) {
-            $command = new CliCommand(
-                $cliConfig['command'],
-                $cliConfig['arguments'] ?? []
-            );
-            return 'created via: ' . $command->asString();
+        $cli = $nodeType->getConfiguration('options.' . KickstartCommandController::OPTION_PATH);
+        if (is_string($cli)) {
+            $cliConfig = json_decode($cli, true);
+            if ($cliConfig && is_array($cliConfig) && array_key_exists('command', $cliConfig)) {
+                $command = new CliCommand(
+                    $cliConfig['command'],
+                    $cliConfig['arguments'] ?? []
+                );
+                return 'created from Sitegeist/Noderobis via: ' . $command->asString();
+            }
         }
         return '';
     }

--- a/Classes/Domain/Generator/CliCommandInfoTrait.php
+++ b/Classes/Domain/Generator/CliCommandInfoTrait.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\Noderobis\Domain\Generator;
+
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Sitegeist\Noderobis\Domain\Specification\CliCommand;
+
+trait CliCommandInfoTrait
+{
+    public function createCliCommandInfoForNodeType (NodeType $nodeType): string
+    {
+        $cliConfig = $nodeType->getConfiguration('options.noderobis.cli');
+        if ($cliConfig) {
+            $command = new CliCommand(
+                $cliConfig['command'],
+                $cliConfig['arguments'] ?? []
+            );
+            return 'created via: ' . $command->asString();
+        }
+        return '';
+    }
+}

--- a/Classes/Domain/Generator/CreateFusionRendererModificationGenerator.php
+++ b/Classes/Domain/Generator/CreateFusionRendererModificationGenerator.php
@@ -19,6 +19,8 @@ use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 
 class CreateFusionRendererModificationGenerator implements ModificationGeneratorInterface
 {
+    use CliCommandInfoTrait;
+
     #[Flow\Inject]
     protected NodeTypeManager $nodeTypeManager;
 
@@ -54,14 +56,12 @@ class CreateFusionRendererModificationGenerator implements ModificationGenerator
         $propertyAcessors = $this->generatePropertyAccessors($nodeType);
         $propertyRenderers = $this->generatePropertyRenderers($nodeType);
         $childNodeRenderer = $this->generateChildrenAfxRenderer($nodeType);
-        $cliCommand = $nodeType->getConfiguration('options.noderobis.cliCommand')
-            ? 'created via: ' . $nodeType->getConfiguration('options.noderobis.cliCommand')
-            : '';
+        $cliCommandInfo = $this->createCliCommandInfoForNodeType($nodeType);
 
         $fusionCode = <<<EOT
             #
             # Renderer for NodeType {$name}
-            # {$cliCommand}
+            # {$cliCommandInfo}
             #
             # @see https://docs.neos.io/cms/manual/rendering
             #
@@ -93,14 +93,12 @@ class CreateFusionRendererModificationGenerator implements ModificationGenerator
         $propertyAcessors = $this->generatePropertyAccessors($nodeType);
         $propertyRenderers = $this->generatePropertyRenderers($nodeType);
         $childNodeRenderer = $this->generateChildrenAfxRenderer($nodeType);
-        $cliCommand = $nodeType->getConfiguration('options.noderobis.cliCommand')
-            ? 'created via: ' . $nodeType->getConfiguration('options.noderobis.cliCommand')
-            : '';
+        $cliCommandInfo = $this->createCliCommandInfoForNodeType($nodeType);
 
         $fusionCode = <<<EOT
             #
             # Renderer for NodeType {$name}
-            # {$cliCommand}
+            # {$cliCommandInfo}
             #
             # @see https://docs.neos.io/cms/manual/rendering
             #

--- a/Classes/Domain/Generator/CreateFusionRendererModificationGenerator.php
+++ b/Classes/Domain/Generator/CreateFusionRendererModificationGenerator.php
@@ -50,15 +50,18 @@ class CreateFusionRendererModificationGenerator implements ModificationGenerator
     protected function createDocumentFusionPrototype(FlowPackageInterface $package, NodeType $nodeType): string
     {
         $name = $nodeType->getName();
-        $packagePath = $package->getPackagePath();
 
         $propertyAcessors = $this->generatePropertyAccessors($nodeType);
         $propertyRenderers = $this->generatePropertyRenderers($nodeType);
         $childNodeRenderer = $this->generateChildrenAfxRenderer($nodeType);
+        $cliCommand = $nodeType->getConfiguration('options.noderobis.cliCommand')
+            ? 'created via: ' . $nodeType->getConfiguration('options.noderobis.cliCommand')
+            : '';
 
         $fusionCode = <<<EOT
             #
             # Renderer for NodeType {$name}
+            # {$cliCommand}
             #
             # @see https://docs.neos.io/cms/manual/rendering
             #
@@ -90,10 +93,14 @@ class CreateFusionRendererModificationGenerator implements ModificationGenerator
         $propertyAcessors = $this->generatePropertyAccessors($nodeType);
         $propertyRenderers = $this->generatePropertyRenderers($nodeType);
         $childNodeRenderer = $this->generateChildrenAfxRenderer($nodeType);
+        $cliCommand = $nodeType->getConfiguration('options.noderobis.cliCommand')
+            ? 'created via: ' . $nodeType->getConfiguration('options.noderobis.cliCommand')
+            : '';
 
         $fusionCode = <<<EOT
             #
             # Renderer for NodeType {$name}
+            # {$cliCommand}
             #
             # @see https://docs.neos.io/cms/manual/rendering
             #

--- a/Classes/Domain/Generator/CreateNodeTypeYamlFileModificationGenerator.php
+++ b/Classes/Domain/Generator/CreateNodeTypeYamlFileModificationGenerator.php
@@ -17,15 +17,16 @@ use Symfony\Component\Yaml\Yaml;
 
 class CreateNodeTypeYamlFileModificationGenerator implements ModificationGeneratorInterface
 {
+    use CliCommandInfoTrait;
+
     public function generateModification(FlowPackageInterface $package, NodeType $nodeType): ModificationInterface
     {
-        $cliCommand = $nodeType->getConfiguration('options.noderobis.cliCommand')
-            ? 'created via: ' . $nodeType->getConfiguration('options.noderobis.cliCommand')
-            : '';
+        $cliCommandInfo = $this->createCliCommandInfoForNodeType($nodeType);
+
         $nodeTypeComment = <<<EOT
             #
             # Definition of NodeType {$nodeType->getName()}
-            # {$cliCommand}
+            # {$cliCommandInfo}
             #
             # @see https://docs.neos.io/cms/manual/content-repository/nodetype-definition
             # @see https://docs.neos.io/cms/manual/content-repository/nodetype-properties

--- a/Classes/Domain/Generator/CreateNodeTypeYamlFileModificationGenerator.php
+++ b/Classes/Domain/Generator/CreateNodeTypeYamlFileModificationGenerator.php
@@ -19,9 +19,13 @@ class CreateNodeTypeYamlFileModificationGenerator implements ModificationGenerat
 {
     public function generateModification(FlowPackageInterface $package, NodeType $nodeType): ModificationInterface
     {
+        $cliCommand = $nodeType->getConfiguration('options.noderobis.cliCommand')
+            ? 'created via: ' . $nodeType->getConfiguration('options.noderobis.cliCommand')
+            : '';
         $nodeTypeComment = <<<EOT
             #
             # Definition of NodeType {$nodeType->getName()}
+            # {$cliCommand}
             #
             # @see https://docs.neos.io/cms/manual/content-repository/nodetype-definition
             # @see https://docs.neos.io/cms/manual/content-repository/nodetype-properties

--- a/Classes/Domain/Specification/CliCommand.php
+++ b/Classes/Domain/Specification/CliCommand.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\Noderobis\Domain\Specification;
+
+use Neos\ContentRepository\Domain\Model\NodeType;
+
+class CliCommand
+{
+    /**
+     * @param string $command
+     * @param array<mixed> $arguments
+     */
+    public function __construct(
+        public readonly string $command,
+        public readonly array  $arguments = []
+    ) {
+    }
+
+    public static function create(BaseType $baseType, ?NodeType $primarySuperType, NodeTypeSpecification $nodeTypeSpecification): static
+    {
+        $name = strtolower($baseType->value);
+        $arguments = [];
+
+        $nameArgument = $nodeTypeSpecification->name->localName;
+        if (str_starts_with( $nameArgument, $baseType->value . '.')) {
+            $nameArgument = preg_replace('/^' . preg_quote($baseType->value . '.', '/') . '/', '', $nameArgument);
+        }
+        $arguments['name'] = $nameArgument;
+        $arguments['packageKey'] = $nodeTypeSpecification->name->packageKey;
+
+        /**
+         * @var NodeTypeNameSpecification $superType
+         */
+        foreach ($nodeTypeSpecification->superTypes->getIterator() as $superType) {
+            if ($primarySuperType && $primarySuperType->getName() === $superType->getFullName()) {
+                continue;
+            }
+            $arguments['superType'][] = (string)$superType;
+        }
+
+        /**
+         * @var PropertySpecification $propertySpecification
+         */
+        foreach ($nodeTypeSpecification->nodeProperties->getIterator() as $propertySpecification) {
+            $arguments['property'][] = (string)$propertySpecification;
+        }
+
+        /**
+         * @var TetheredNodeSpecification $tetheredNode
+         */
+        foreach ($nodeTypeSpecification->tetheredNodes->getIterator() as $tetheredNode) {
+            $arguments['childNode'][] = (string)$tetheredNode;
+        }
+
+        if ($nodeTypeSpecification->abstract) {
+            $arguments['abstract'] = true;
+        }
+
+        if ($nodeTypeSpecification->icon) {
+            $arguments['icon'] = $nodeTypeSpecification->icon->name;;
+        }
+
+        if ($nodeTypeSpecification->label) {
+            $arguments['label'] = $nodeTypeSpecification->label->label;
+        }
+
+        return new static(
+            $name,
+            $arguments
+        );
+    }
+
+    public function asString(): string
+    {
+        $command = './flow ' . $this->command;
+        foreach ($this->arguments as $argumentName => $value) {
+            if (is_string($value)) {
+                $command .= ' --' . $argumentName . ' ' . $value;
+            } elseif (is_bool($value) && $value === true) {
+                $command .= ' --' . $argumentName;
+            } if (is_array($value)) {
+                foreach ($value as $item) {
+                    $command .= ' --' . $argumentName . ' ' . $item;
+                }
+            }
+        }
+        return $command;
+    }
+
+    public function asArray(): array
+    {
+        return [
+            'command' => $this->command,
+            'arguments' => $this->arguments
+        ];
+    }
+
+}

--- a/Classes/Domain/Specification/CliCommand.php
+++ b/Classes/Domain/Specification/CliCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sitegeist\Noderobis\Domain\Specification;
@@ -13,7 +14,7 @@ class CliCommand
      */
     public function __construct(
         public readonly string $command,
-        public readonly array  $arguments = []
+        public readonly array $arguments = []
     ) {
     }
 
@@ -23,7 +24,7 @@ class CliCommand
         $arguments = [];
 
         $nameArgument = $nodeTypeSpecification->name->localName;
-        if (str_starts_with( $nameArgument, $baseType->value . '.')) {
+        if (str_starts_with($nameArgument, $baseType->value . '.')) {
             $nameArgument = preg_replace('/^' . preg_quote($baseType->value . '.', '/') . '/', '', $nameArgument);
         }
         $arguments['name'] = $nameArgument;
@@ -58,7 +59,8 @@ class CliCommand
         }
 
         if ($nodeTypeSpecification->icon) {
-            $arguments['icon'] = $nodeTypeSpecification->icon->name;;
+            $arguments['icon'] = $nodeTypeSpecification->icon->name;
+            ;
         }
 
         if ($nodeTypeSpecification->label) {
@@ -88,6 +90,9 @@ class CliCommand
         return $command;
     }
 
+    /**
+     * @return array{'command':string, 'arguments':mixed[]}
+     */
     public function asArray(): array
     {
         return [
@@ -96,4 +101,18 @@ class CliCommand
         ];
     }
 
+    /**
+     * @param mixed $config
+     */
+    public static function fromConfiguration(mixed $config): static
+    {
+        if (is_array($config) && array_key_exists('command', $config)) {
+            return new static(
+                $config['command'],
+                $config['arguments'] ?? []
+            );
+        } else {
+            throw new \InvalidArgumentException('Not a valid cli command config');
+        }
+    }
 }

--- a/Classes/Domain/Specification/CliCommand.php
+++ b/Classes/Domain/Specification/CliCommand.php
@@ -60,7 +60,6 @@ class CliCommand
 
         if ($nodeTypeSpecification->icon) {
             $arguments['icon'] = $nodeTypeSpecification->icon->name;
-            ;
         }
 
         if ($nodeTypeSpecification->label) {
@@ -75,7 +74,7 @@ class CliCommand
 
     public function asString(): string
     {
-        $command = './flow ' . $this->command;
+        $command = './flow kickstart:' . $this->command;
         foreach ($this->arguments as $argumentName => $value) {
             if (is_string($value)) {
                 $command .= ' --' . $argumentName . ' ' . $value;

--- a/Classes/Domain/Specification/OptionsSpecification.php
+++ b/Classes/Domain/Specification/OptionsSpecification.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sitegeist\Noderobis\Domain\Specification;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Utility\Arrays;
 
 #[Flow\Proxy(false)]
 class OptionsSpecification
@@ -15,5 +16,16 @@ class OptionsSpecification
     public function __construct(
         public readonly ?array $options
     ) {
+    }
+
+    public function withOption(string $path, mixed $value): static
+    {
+        /**
+         * @var array<mixed> $newOptions
+         */
+        $newOptions = Arrays::setValueByPath($this->options ?? [], $path, $value);
+        return new static(
+            $newOptions
+        );
     }
 }

--- a/Classes/Domain/Specification/PropertyPresetNameSpecification.php
+++ b/Classes/Domain/Specification/PropertyPresetNameSpecification.php
@@ -16,6 +16,6 @@ class PropertyPresetNameSpecification
 
     public function __toString(): string
     {
-        return 'preset:' . $this->presetName;
+        return 'preset.' . $this->presetName;
     }
 }

--- a/Classes/Domain/Specification/PropertySpecification.php
+++ b/Classes/Domain/Specification/PropertySpecification.php
@@ -22,11 +22,10 @@ class PropertySpecification
 
     public function __toString(): string
     {
-        $string = $this->name->name . '(' . $this->typeOrPreset;
+        $string = $this->name->name . ':' . $this->typeOrPreset;
         if ($this->allowedValues) {
             $string .= ':' . $this->allowedValues;
         }
-        $string .= ')';
         return $string;
     }
 }


### PR DESCRIPTION
The `./flow kickstart:refine` command takes a NodeType as argument and checks wether this nodetype was created by the kickstarter. This is done by checking the path `options.noderobis.__cliInternal` that stores the informations required to continue kickstarting.

Additionally:
- a hint about the flow-command used for kickstarting is added to the comment at the beginning of the generated yaml and fusion files
- the format for property preview now uses the same format as the cli
- the cli options `--icon` and `--label` were added for the `kickstart:content` and `kickstart:document` commands
- the cli option `--mixin` was renamed to `--superType`